### PR TITLE
Enhancements for memory usage testing

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -49,6 +49,7 @@ func createLoadSpecFromArgs() sgload.LoadSpec {
 		NumChannels:          *numChannels,
 		DocSizeBytes:         *docSizeBytes,
 		NumDocs:              *numDocs,
+		CompressionEnabled:   *compressionEnabled,
 	}
 	loadSpec.TestSessionID = sgload.NewUuid()
 	return loadSpec

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,17 +9,18 @@ import (
 )
 
 var (
-	cfgFile        string
-	sgUrl          *string
-	sgAdminPort    *int
-	mockDataStore  *bool
-	statsdEndpoint *string
-	statsdEnabled  *bool
-	testSessionID  *string
-	numChannels    *int
-	numDocs        *int
-	docSizeBytes   *int
-	batchSize      *int
+	cfgFile            string
+	sgUrl              *string
+	sgAdminPort        *int
+	mockDataStore      *bool
+	statsdEndpoint     *string
+	statsdEnabled      *bool
+	testSessionID      *string
+	numChannels        *int
+	numDocs            *int
+	docSizeBytes       *int
+	batchSize          *int
+	compressionEnabled *bool
 )
 
 // This represents the base command when called without any subcommands
@@ -108,6 +109,12 @@ func init() {
 		"batchsize",
 		1,
 		"The batch size that will be used for writing docs via bulk_docs endpoint",
+	)
+
+	compressionEnabled = RootCmd.PersistentFlags().Bool(
+		"compressionenabled",
+		false,
+		"Whether gzip compression is enabled",
 	)
 
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.sgload.yaml)")

--- a/sgload/doc_feeder.go
+++ b/sgload/doc_feeder.go
@@ -89,7 +89,7 @@ func createDocsToWrite(numDocs, docSizeBytes int, docIdSuffix string) []Document
 			d["_id"] = fmt.Sprintf("%d-%s", docNum, docIdSuffix)
 		}
 		d["docNum"] = docNum
-		d["body"] = createBodyContentWithSize(docSizeBytes)
+		d["body"] = createBodyContentAsMapWithSize(docSizeBytes)
 		d["created_at"] = time.Now().Format(time.RFC3339Nano)
 		docs = append(docs, d)
 	}

--- a/sgload/load_runner.go
+++ b/sgload/load_runner.go
@@ -39,6 +39,7 @@ func (lr LoadRunner) createDataStore() DataStore {
 		lr.LoadSpec.SyncGatewayUrl,
 		lr.LoadSpec.SyncGatewayAdminPort,
 		lr.StatsdClient,
+		lr.LoadSpec.CompressionEnabled,
 	)
 
 	return sgDataStore

--- a/sgload/loadspec.go
+++ b/sgload/loadspec.go
@@ -19,6 +19,7 @@ type LoadSpec struct {
 	NumChannels          int    // How many channels to create/use during this test
 	DocSizeBytes         int    // Doc size in bytes to create during this test
 	NumDocs              int    // Number of docs to read/write during this test
+	CompressionEnabled   bool   // Whether requests and responses should be compressed (when supported)
 }
 
 func (ls LoadSpec) Validate() error {

--- a/sgload/updateload_runner.go
+++ b/sgload/updateload_runner.go
@@ -110,6 +110,7 @@ func (ulr UpdateLoadRunner) createUpdaters(wg *sync.WaitGroup, userCreds []UserC
 			dataStore,
 			ulr.UpdateLoadSpec.NumRevsPerDoc,
 			docsForUpdater,
+			ulr.UpdateLoadSpec.BatchSize,
 		)
 		updater.SetStatsdClient(ulr.StatsdClient)
 		updaters = append(updaters, updater)

--- a/sgload/updater.go
+++ b/sgload/updater.go
@@ -23,7 +23,7 @@ type DocUpdateStatus struct {
 	LatestRev  string
 }
 
-func NewUpdater(wg *sync.WaitGroup, ID int, u UserCred, d DataStore, n int, da []Document) *Updater {
+func NewUpdater(wg *sync.WaitGroup, ID int, u UserCred, d DataStore, n int, da []Document, batchsize int) *Updater {
 
 	docsToUpdate := make(chan []sgreplicate.DocumentRevisionPair, 100)
 
@@ -37,7 +37,7 @@ func NewUpdater(wg *sync.WaitGroup, ID int, u UserCred, d DataStore, n int, da [
 		DocsToUpdate:             docsToUpdate,
 		NumUpdatesPerDocRequired: n,
 		DocUpdateStatuses:        map[string]DocUpdateStatus{},
-		BatchSize:                5, // TODO: parameterize
+		BatchSize:                batchsize,
 		DocsAssignedToUpdater:    da,
 	}
 

--- a/sgload/writeload_runner.go
+++ b/sgload/writeload_runner.go
@@ -2,6 +2,7 @@ package sgload
 
 import (
 	"bytes"
+	"fmt"
 	"sync"
 )
 
@@ -142,4 +143,16 @@ func createBodyContentWithSize(docSizeBytes int) string {
 		buf.WriteString("a")
 	}
 	return buf.String()
+}
+
+// Create body content as map of 100 byte entries.  Rounds up to the nearest 100 bytes
+func createBodyContentAsMapWithSize(docSizeBytes int) map[string]string {
+
+	numEntries := int(docSizeBytes/100) + 1
+	body := make(map[string]string, numEntries)
+	for i := 0; i < numEntries; i++ {
+		key := fmt.Sprintf("field_%d", i)
+		body[key] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	}
+	return body
 }


### PR DESCRIPTION
- Support for gzip compression of bulk_docs requests using --compressionenabled flag
- Writes doc content as map instead of single string field
- Uses existing batchsize parameter for updater bulk docs requests
