### PR TITLE
Add support for new_edits=false, multiple revisions per update

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -33,7 +33,11 @@ const (
 
 	NUM_REVS_PER_DOC_CMD_NAME    = "numrevsperdoc"
 	NUM_REVS_PER_DOC_CMD_DEFAULT = 100
-	NUM_REVS_PER_DOC_CMD_DESC    = "The number of revisions per doc to add updates for"
+	NUM_REVS_PER_DOC_CMD_DESC    = "The number of updates per doc (total revs will be numrevsperdoc * numrevsperupdate)"
+
+	NUM_REVS_PER_UPDATE_CMD_NAME    = "numrevsperupdate"
+	NUM_REVS_PER_UPDATE_CMD_DEFAULT = 1
+	NUM_REVS_PER_UPDATE_CMD_DESC    = "The number of revisions per doc to add in each update"
 )
 
 func createLoadSpecFromArgs() sgload.LoadSpec {

--- a/cmd/gateload.go
+++ b/cmd/gateload.go
@@ -47,9 +47,9 @@ var gateloadCmd = &cobra.Command{
 		}
 
 		updateLoadSpec := sgload.UpdateLoadSpec{
-			LoadSpec:      loadSpec,
-			NumRevsPerDoc: *glNumRevsPerDoc,
-			NumUpdaters:   *glNumUpdaters,
+			LoadSpec:         loadSpec,
+			NumUpdatesPerDoc: *glNumRevsPerDoc,
+			NumUpdaters:      *glNumUpdaters,
 		}
 
 		gateLoadSpec := sgload.GateLoadSpec{

--- a/cmd/updateload.go
+++ b/cmd/updateload.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	numRevsPerDoc           *int
+	numUpdatesPerDoc        *int
+	numRevsPerUpdate        *int
 	numUpdaters             *int
 	updateLoadSkipWriteload *bool
 	updateLoadNumWriters    *int
@@ -30,9 +31,10 @@ var updateloadCmd = &cobra.Command{
 
 		loadSpec := createLoadSpecFromArgs()
 		updateLoadSpec := sgload.UpdateLoadSpec{
-			LoadSpec:      loadSpec,
-			NumRevsPerDoc: *numRevsPerDoc,
-			NumUpdaters:   *numUpdaters,
+			LoadSpec:         loadSpec,
+			NumUpdatesPerDoc: *numUpdatesPerDoc,
+			NumRevsPerUpdate: *numRevsPerUpdate,
+			NumUpdaters:      *numUpdaters,
 		}
 		logger.Info("created update loadspec", "updateLoadSpec", fmt.Sprintf("%+v", updateLoadSpec))
 
@@ -85,10 +87,16 @@ func init() {
 		SKIP_WRITELOAD_CMD_DESC,
 	)
 
-	numRevsPerDoc = updateloadCmd.PersistentFlags().Int(
+	numUpdatesPerDoc = updateloadCmd.PersistentFlags().Int(
 		NUM_REVS_PER_DOC_CMD_NAME,
 		NUM_REVS_PER_DOC_CMD_DEFAULT,
 		NUM_REVS_PER_DOC_CMD_DESC,
+	)
+
+	numRevsPerUpdate = updateloadCmd.PersistentFlags().Int(
+		NUM_REVS_PER_UPDATE_CMD_NAME,
+		NUM_REVS_PER_UPDATE_CMD_DEFAULT,
+		NUM_REVS_PER_UPDATE_CMD_DESC,
 	)
 
 	numUpdaters = updateloadCmd.PersistentFlags().Int(

--- a/sgload/gateload_runner.go
+++ b/sgload/gateload_runner.go
@@ -66,7 +66,7 @@ func (glr GateLoadRunner) Run() error {
 		"numchannels",
 		glr.GateLoadSpec.NumChannels,
 		"numrevsperdoc",
-		glr.GateLoadSpec.NumRevsPerDoc,
+		glr.GateLoadSpec.NumUpdatesPerDoc,
 	)
 
 	// Start Writers

--- a/sgload/mockdatastore.go
+++ b/sgload/mockdatastore.go
@@ -22,7 +22,7 @@ func (m MockDataStore) CreateDocument(d Document) (sgreplicate.DocumentRevisionP
 	return sgreplicate.DocumentRevisionPair{}, nil
 }
 
-func (m MockDataStore) BulkCreateDocuments(docs []Document) ([]sgreplicate.DocumentRevisionPair, error) {
+func (m MockDataStore) BulkCreateDocuments(docs []Document, newEdits bool) ([]sgreplicate.DocumentRevisionPair, error) {
 	log.Printf("MockDataStore BulkCreateDocuments called with %d docs", len(docs))
 	return []sgreplicate.DocumentRevisionPair{}, nil
 }

--- a/sgload/sg_datastore.go
+++ b/sgload/sg_datastore.go
@@ -191,7 +191,7 @@ func (s SGDataStore) Changes(sinceVal Sincer, limit int) (changes sgreplicate.Ch
 // Create a single document in Sync Gateway
 func (s SGDataStore) CreateDocument(d Document) (sgreplicate.DocumentRevisionPair, error) {
 
-	docRevisionPairs, err := s.BulkCreateDocuments([]Document{d})
+	docRevisionPairs, err := s.BulkCreateDocuments([]Document{d}, true)
 	if err != nil {
 		return sgreplicate.DocumentRevisionPair{}, err
 	}
@@ -203,7 +203,7 @@ func (s SGDataStore) CreateDocument(d Document) (sgreplicate.DocumentRevisionPai
 }
 
 // Bulk create a set of documents in Sync Gateway
-func (s SGDataStore) BulkCreateDocuments(docs []Document) ([]sgreplicate.DocumentRevisionPair, error) {
+func (s SGDataStore) BulkCreateDocuments(docs []Document, newEdits bool) ([]sgreplicate.DocumentRevisionPair, error) {
 
 	defer s.pushCounter("create_document_counter", len(docs))
 
@@ -220,8 +220,9 @@ func (s SGDataStore) BulkCreateDocuments(docs []Document) ([]sgreplicate.Documen
 
 	bulkDocs := BulkDocs{
 		Documents: docs,
-		NewEdits:  true,
+		NewEdits:  newEdits,
 	}
+
 	docBytes, err := json.Marshal(bulkDocs)
 	if err != nil {
 		return bulkDocsResponse, err

--- a/sgload/updateload_runner.go
+++ b/sgload/updateload_runner.go
@@ -108,9 +108,10 @@ func (ulr UpdateLoadRunner) createUpdaters(wg *sync.WaitGroup, userCreds []UserC
 			userId,
 			userCred,
 			dataStore,
-			ulr.UpdateLoadSpec.NumRevsPerDoc,
+			ulr.UpdateLoadSpec.NumUpdatesPerDoc,
 			docsForUpdater,
 			ulr.UpdateLoadSpec.BatchSize,
+			ulr.UpdateLoadSpec.NumRevsPerUpdate,
 		)
 		updater.SetStatsdClient(ulr.StatsdClient)
 		updaters = append(updaters, updater)

--- a/sgload/updateload_spec.go
+++ b/sgload/updateload_spec.go
@@ -4,8 +4,9 @@ import "log"
 
 type UpdateLoadSpec struct {
 	LoadSpec
-	NumRevsPerDoc int // The number of revisions to add per doc
-	NumUpdaters   int // The number of updater goroutines
+	NumUpdatesPerDoc int // The total number of revisions to add per doc
+	NumRevsPerUpdate int // The number of revisions to add per update
+	NumUpdaters      int // The number of updater goroutines
 }
 
 func (uls UpdateLoadSpec) Validate() error {

--- a/sgload/writer.go
+++ b/sgload/writer.go
@@ -59,7 +59,7 @@ func (w *Writer) Run() {
 				w.notifyDocPushed(docRevPair)
 
 			default:
-				docRevPairs, err := w.DataStore.BulkCreateDocuments(docs)
+				docRevPairs, err := w.DataStore.BulkCreateDocuments(docs, true)
 				if err != nil {
 					panic(fmt.Sprintf("Error creating docs in datastore.  Docs: %v, Err: %v", docs, err))
 				}


### PR DESCRIPTION
To better simulate client behaviour, updater is switched to use new_edits=false style of update.

In addition, adds the ability for the updater to simulate a client making multiple updates to a document while offline, using the numrevsperupdate property.

When numrevsperupdate=n, the updater will add n-1 additional revisions to the rev history when updating the doc, i.e. for initial doc with rev 1-foo:
1. If numrevsperupdate=1, updater creates new revision 2-foo, with parent 1-foo (default behaviour)
2. If numrevsperupdate=3, updater creates new revision 4-foo, with history 3-bar, 2-bar, 1-foo.

The current revision ID is calculated using the standard rev digest algorithm (4-foo, 2-foo, above).  Intermediate revision ids are generated as random digest values (3-bar, 2-bar above).
