### PR TITLE
Fixes #23 by bumping the max idle connections per host

### DIFF
--- a/sgload/sg_datastore.go
+++ b/sgload/sg_datastore.go
@@ -26,7 +26,30 @@ var (
 	// want 1% of the samples pushed to statsd.  Useful for
 	// not overwhelming stats if you have too many samples.
 	statsdSampleRate float32 = 1.0
+
+	sgClient *http.Client
 )
+
+func init() {
+
+	// In order to fix issues observed in https://github.com/couchbaselabs/sgload/issues/23
+	// bump up the max idle connections per host to 100
+	tr := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          1000,
+		MaxIdleConnsPerHost:   100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	sgClient = &http.Client{Transport: tr}
+
+}
 
 type SGDataStore struct {
 	SyncGatewayUrl       string
@@ -78,7 +101,7 @@ func (s SGDataStore) CreateUser(u UserCred, channelNames []string) error {
 
 	req.Header.Set("Content-Type", "application/json")
 
-	client := http.DefaultClient
+	client := getHttpClient()
 
 	startTime := time.Now()
 	resp, err := client.Do(req)
@@ -159,7 +182,7 @@ func (s SGDataStore) Changes(sinceVal Sincer, limit int) (changes sgreplicate.Ch
 
 	req.Header.Set("Content-Type", "application/json")
 
-	client := http.DefaultClient
+	client := getHttpClient()
 
 	startTime := time.Now()
 	resp, err := client.Do(req)
@@ -250,7 +273,7 @@ func (s SGDataStore) BulkCreateDocuments(docs []Document, newEdits bool) ([]sgre
 		req.Header.Set("Content-Encoding", "gzip")
 	}
 
-	client := http.DefaultClient
+	client := getHttpClient()
 
 	startTime := time.Now()
 	resp, err := client.Do(req)
@@ -301,7 +324,7 @@ func (s SGDataStore) BulkGetDocuments(r sgreplicate.BulkGetRequest) ([]sgreplica
 
 	req.Header.Set("Content-Type", "application/json")
 
-	client := http.DefaultClient
+	client := getHttpClient()
 
 	startTime := time.Now()
 	resp, err := client.Do(req)
@@ -455,4 +478,9 @@ func timeDeltaPerDocument(numDocs int, timeDeltaAllDocs time.Duration) time.Dura
 		return timeDeltaAllDocs
 	}
 	return time.Duration(int64(timeDeltaAllDocs) / int64(numDocs))
+}
+
+func getHttpClient() *http.Client {
+	// return http.DefaultClient
+	return sgClient
 }


### PR DESCRIPTION
Fixes #23 

I wrote up a [blog post](http://tleyden.github.io/blog/2016/11/21/tuning-the-go-http-client-library-for-load-testing/) to try to explain the problem and repro in a simple test case.  The simple test case repro didn't work, but testing in the actual scenario for #23 did reduce the number of `TIME_WAIT` connections to 0.

 