### PR TITLE
Use g2s.Statter interface and fallback to mock no-ops everything

### DIFF
--- a/sgload/agent.go
+++ b/sgload/agent.go
@@ -21,7 +21,7 @@ type AgentSpec struct {
 // Contains common fields and functionality between readers and writers
 type Agent struct {
 	AgentSpec
-	StatsdClient *g2s.Statsd          // The statsd client instance to use to push stats to statdsd
+	StatsdClient g2s.Statter          // The statsd client instance to use to push stats to statdsd
 	ExpVarStats  ExpVarStatsCollector // The expvar progress stats map for this agent
 }
 
@@ -38,7 +38,7 @@ func (a *Agent) createSGUserIfNeeded(channels []string) {
 
 }
 
-func (a *Agent) SetStatsdClient(statsdClient *g2s.Statsd) {
+func (a *Agent) SetStatsdClient(statsdClient g2s.Statter) {
 	a.StatsdClient = statsdClient
 }
 

--- a/sgload/load_runner.go
+++ b/sgload/load_runner.go
@@ -8,12 +8,12 @@ import (
 
 type LoadRunner struct {
 	LoadSpec     LoadSpec
-	StatsdClient *g2s.Statsd
+	StatsdClient g2s.Statter
 }
 
 func (lr *LoadRunner) CreateStatsdClient() {
 
-	var statsdClient *g2s.Statsd
+	var statsdClient g2s.Statter
 	var err error
 
 	if lr.LoadSpec.StatsdEnabled {
@@ -23,6 +23,8 @@ func (lr *LoadRunner) CreateStatsdClient() {
 		if err != nil {
 			panic("Couldn't connect to statsd!")
 		}
+	} else {
+		statsdClient = MockStatter{}
 	}
 
 	lr.StatsdClient = statsdClient

--- a/sgload/mock_statsd.go
+++ b/sgload/mock_statsd.go
@@ -1,0 +1,11 @@
+package sgload
+
+import "time"
+
+type MockStatter struct{}
+
+func (ms MockStatter) Counter(sampleRate float32, bucket string, n ...int) {}
+
+func (ms MockStatter) Timing(sampleRate float32, bucket string, d ...time.Duration) {}
+
+func (ms MockStatter) Gauge(sampleRate float32, bucket string, value ...string) {}

--- a/sgload/sg_datastore.go
+++ b/sgload/sg_datastore.go
@@ -39,11 +39,11 @@ type SGDataStore struct {
 	SyncGatewayUrl       string
 	SyncGatewayAdminPort int
 	UserCreds            UserCred
-	StatsdClient         *g2s.Statsd
+	StatsdClient         g2s.Statter
 	CompressionEnabled   bool
 }
 
-func NewSGDataStore(sgUrl string, sgAdminPort int, statsdClient *g2s.Statsd, compressionEnabled bool) *SGDataStore {
+func NewSGDataStore(sgUrl string, sgAdminPort int, statsdClient g2s.Statter, compressionEnabled bool) *SGDataStore {
 	return &SGDataStore{
 		SyncGatewayUrl:       sgUrl,
 		SyncGatewayAdminPort: sgAdminPort,
@@ -415,9 +415,6 @@ func (s SGDataStore) addAuthIfNeeded(req *http.Request) {
 }
 
 func (s SGDataStore) pushTimingStat(key string, delta time.Duration) {
-	if s.StatsdClient == nil {
-		return
-	}
 	s.StatsdClient.Timing(
 		statsdSampleRate,
 		key,
@@ -426,9 +423,6 @@ func (s SGDataStore) pushTimingStat(key string, delta time.Duration) {
 }
 
 func (s SGDataStore) pushCounter(key string, n int) {
-	if s.StatsdClient == nil {
-		return
-	}
 	s.StatsdClient.Counter(
 		statsdSampleRate,
 		key,


### PR DESCRIPTION
I noticed that g2s has a `Statter` interface.  Use the interface rather than pinning to their impl